### PR TITLE
Fix auto-select to select first visible row

### DIFF
--- a/src/views/request-list.tsx
+++ b/src/views/request-list.tsx
@@ -61,10 +61,14 @@ export class RequestList extends Component<IRequestListProps, IRecordListState> 
     }
 
     componentDidUpdate(previousProps: Readonly<IRequestListProps>): void {
-        if (this.props.har.name != previousProps.har.name) {
-            // automatically selecting the first row after loading the file
+        // checking whether new file was loaded or filter changed
+        if (this.props.har.name != previousProps.har.name || 
+            this.props.menuOptions?.showHighlightedRequestsOnly != previousProps.menuOptions?.showHighlightedRequestsOnly) {
+
             this.currentlySelectedIndex = -1;
-            this.selectRequest(defaultSelectedRow);
+
+            // selecting the first (visible) row after loading the file
+            this.selectRequest(this.requestIndexList[0] || defaultSelectedRow);
         }
     }
 


### PR DESCRIPTION
Before it was always selecting the index=0 row which not always was visible.

In addition we're selecting the first visible row after filter is applied